### PR TITLE
Corrected spelling mistakes in docs

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -14,12 +14,12 @@ description: "Welcome to Clickvote"
   alt="Hero Dark"
 />
 
-Clickvote is an open-source likes and upvotes infrastructure powered by websockets. It allows to seamleslly integrate like and upvotes components
+Clickvote is an open-source likes and upvotes infrastructure powered by websockets. It allows to seamlessly integrate like and upvotes components
 into any website, SPA or a no-code tool.
 
 There is absolutely no reason any developer should ever build upvotes infrastructure from scratch. Clickvote makes so many things easy for you:
 
-- Multipe pre-built components (likes, ratings, stars, feedback)
+- Multiple pre-built components (likes, ratings, stars, feedback)
 - SDKs for your favorite framework (React, Vue, Svelte, HTML, etc)
 - Instant analytics (URL, time, geo)
 - Zero headaches managing websockets!


### PR DESCRIPTION
Fixed spellings of 'seamlessly' and 'multiple' in introduction page of docs

(Issue #89 of the main repo)